### PR TITLE
feat: Add error library and examples for error management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aba2d96b8c8b5e656ad7ffb0d09f57772f10a1db74c8d23fca0ec695b38a4047"
 
 [[package]]
+name = "anyhow"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
+
+[[package]]
 name = "arrayvec"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,8 +162,10 @@ dependencies = [
 name = "dhall-mock"
 version = "0.0.1"
 dependencies = [
+ "anyhow",
  "serde",
  "serde_dhall",
+ "thiserror",
 ]
 
 [[package]]
@@ -1120,6 +1128,26 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0570dc61221295909abdb95c739f2e74325e14293b2026b0a7e195091ec54ae"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227362df41d566be41a28f64401e07a043157c21c14b9785a0d8e256f940a8fd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ edition = "2018"
 [dependencies]
 serde = "1.0"
 serde_dhall = "0.5"
+anyhow = "1.0"
+thiserror = "1.0"
+

--- a/examples/errors/main.rs
+++ b/examples/errors/main.rs
@@ -1,0 +1,68 @@
+use std::fmt::Display;
+use std::fs;
+
+use serde::export::Formatter;
+use thiserror;
+
+use anyhow::{anyhow, Context, Error};
+
+fn define_error() -> Result<(), Error> {
+    Err(anyhow!("Custom error from anyhow!"))
+}
+
+fn context_error() -> Result<(), Error> {
+    define_error().context("Added some context using context function")
+}
+
+#[derive(thiserror::Error, Debug)]
+struct StructuredContext {
+    message: String,
+    value: u8,
+}
+
+unsafe impl Send for StructuredContext {}
+unsafe impl Sync for StructuredContext {}
+
+impl Display for StructuredContext {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "Structured context using context : {:?}", self)
+    }
+}
+
+fn define_structured_context(message: String, value: u8) -> Result<(), Error> {
+    context_error().context(StructuredContext { message, value })
+}
+
+fn augment_external_errors() -> Result<(), Error> {
+    fs::read_to_string("file_that_does_not_exists")
+        .map(|_| ())
+        .context("Error reading file")
+}
+
+fn main() {
+    match define_structured_context("param string".to_string(), 42) {
+        Ok(_) => eprintln!("Can't be ok"),
+        Err(err) => {
+            println!("Current error message : {}", err);
+            println!();
+            println!("Print chain of errors");
+            for error in err.chain() {
+                println!("{}", error)
+            }
+            println!();
+        }
+    }
+    match augment_external_errors() {
+        Ok(_) => eprintln!("Can't be ok"),
+        Err(err) => {
+            println!("Current error message : {}", err);
+            println!();
+            println!("Search for specific std::io::Error");
+            match err.downcast::<std::io::Error>() {
+                Ok(io_error) => println!("Downcasted to std::io::Error {}", io_error),
+                Err(cast_error) => eprintln!("Error downcasting : {}", cast_error),
+            }
+            println!();
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,23 @@
+use anyhow::{Context, Error};
 use serde::Deserialize;
 
-fn main() {
+fn main() -> Result<(), Error> {
     println!("Hello from dhall mock project 👋");
 
     // Some Dhall data
     let data = r###"
         let Mock = ./dhall/Mock/package.dhall
-        in Mock.HttpMethod.GET
+        in Mock.HttpMethod.UNKNOW
     "###;
 
     // Deserialize it to a Rust type.
-    let method: HttpMethod = serde_dhall::from_str(data).parse().unwrap();
+    let method: HttpMethod = serde_dhall::from_str(data)
+        .parse()
+        .context("Parsing dhall configuration")?;
 
     assert_eq!(method, HttpMethod::GET);
+
+    Ok(())
 }
 
 #[derive(Debug, Deserialize, PartialEq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Error> {
     // Some Dhall data
     let data = r###"
         let Mock = ./dhall/Mock/package.dhall
-        in Mock.HttpMethod.UNKNOW
+        in Mock.HttpMethod.GET
     "###;
 
     // Deserialize it to a Rust type.


### PR DESCRIPTION
### Why ths PR ?

This PR add `anyhow` and `thiserror` crates for clean error management.  
The PR come with examples of how you can use this crates for error declaration, context additon and downcasting for a good basic usage of these crates in [examples/errors](https://github.com/dhall-mock/dhall-mock/pull/10/files#diff-39fef3daa36097d29ccbf7d1102a3a0dR42)

To run error examples : `cargo run --package dhall-mock --example errors`

### Related
Closes: #4 
