### PR TITLE
Add cli for program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aba2d96b8c8b5e656ad7ffb0d09f57772f10a1db74c8d23fca0ec695b38a4047"
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +153,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 
 [[package]]
+name = "clap"
+version = "2.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "colored"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +232,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_dhall",
+ "structopt",
  "thiserror",
  "tokio",
 ]
@@ -407,6 +432,15 @@ name = "half"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36b5f248235f45773d4944f555f83ea61fe07b18b561ccf99d7483d7381e54d"
+
+[[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -920,6 +954,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "syn-mid",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,6 +1355,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8faa2719539bbe9d77869bfb15d4ee769f99525e707931452c97b693b3f159d"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88b8e18c69496aad6f9ddf4630dd7d585bcaf765786cb415b9aec2fe5a0430"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,6 +1393,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1326,6 +1427,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1485,6 +1595,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,6 +1634,12 @@ name = "vcpkg"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ rustls = "0.17"
 hyper = "0.13"
 tokio = { version = "0.2", features = ["full", "time"] }
 bytes = "0.5"
+structopt = "0.3"

--- a/dhall/static2.dhall
+++ b/dhall/static2.dhall
@@ -1,0 +1,14 @@
+let Mock = ./dhall/Mock/package.dhall
+
+let expectations = [
+                       { request  = { method  = Some Mock.HttpMethod.GET
+                                   , path    = Some "/greet/warcraft3"
+                                   }
+                       , response = { statusCode   = Some +200
+                                       , statusReason = None Text
+                                       , body         = Some "Oui monseigneur"
+                                       }
+                      }
+                   ]
+
+in expectations

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,16 @@
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug, Clone)]
+#[structopt(name = "dhall-mock")]
+pub struct CliOpt {
+    /// Dhall configuration files to parse
+    #[structopt(required = true)]
+    pub configuration_files: Vec<String>,
+    /// http binding for server
+    #[structopt(short, long, default_value = "0.0.0.0:8088")]
+    pub http_bind: String,
+}
+
+pub fn load_cli_args() -> CliOpt {
+    CliOpt::from_args()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,12 @@
-use std::env;
-
-use anyhow::{anyhow, Error};
+use anyhow::{Context, Error};
 use env_logger::Env;
-use log::info;
+use log::{debug, info, warn};
 
 use crate::compiler::{compile_configuration, load_file};
 use crate::web::State;
 use std::sync::{Arc, RwLock};
 
+mod cli;
 mod compiler;
 mod expectation;
 mod mock;
@@ -17,19 +16,31 @@ mod web;
 async fn main() -> Result<(), Error> {
     start_logger();
 
-    let args: Vec<String> = env::args().collect();
-    let filename = args
-        .get(1)
-        .ok_or(anyhow!("Program need 1 argument : File configuration path"))?;
+    let cli_args = cli::load_cli_args();
 
     info!("Start dhall mock project 👋");
-    let configuration = load_file(filename)?;
-    let expectations = compile_configuration(&configuration)?;
+
+    let expectations = cli_args
+        .configuration_files
+        .iter()
+        .flat_map(|configuration_file| {
+            debug!("Loading configuration file {}", configuration_file);
+            let configuration_result = load_file(configuration_file)
+                .and_then(|configuration| compile_configuration(&configuration))
+                .context("Error loading configuration");
+            match configuration_result {
+                Ok(expectations) => expectations.into_iter(),
+                Err(e) => {
+                    warn!("{}", e);
+                    Vec::new().into_iter()
+                }
+            }
+        })
+        .collect();
     info!("Loaded expectations : {:?}", expectations);
 
     let state = Arc::new(RwLock::new(State { expectations }));
-    // TODO load http bind from config
-    web::web_server(state.clone(), "0.0.0.0:8088".to_string()).await?;
+    web::web_server(state.clone(), cli_args.http_bind).await?;
 
     Ok(())
 }


### PR DESCRIPTION
## What this PR does

Include [structopt](https://docs.rs/structopt/0.3.12/structopt/) crate for cli args parsing.  
Define a CLI with following args :
```
dhall-mock 0.0.1

USAGE:
    dhall-mock [OPTIONS] <configuration-files>...

FLAGS:
        --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -h, --http-bind <http-bind>    http binding for server [default: 0.0.0.0:8088]

ARGS:
    <configuration-files>...    Dhall configuration files to parse
```

The program read all configurations files (warn on compilation error for each one) and start web server using this configuration.

## Related

Closes: #25 
Related : #26 (depends on)

## Special notes for your reviewer

To inspect cli : `cargo build` --> `./target/debug/dhall-mock`

You can check loading of multpiple files using : `./target/debug/dhall-mock dhall/static.dhall dhall/static2.dhall`

