### PR TITLE
Configure configuration laod to be executed in separate runtime

### DIFF
--- a/dhall/error.dhall
+++ b/dhall/error.dhall
@@ -11,4 +11,4 @@ let expectations = [
                       }
                    ]
 
-in expectations
+in expectation

--- a/dhall/example.dhall
+++ b/dhall/example.dhall
@@ -1,10 +1,10 @@
-let Prelude = https://prelude.dhall-lang.org/package.dhall
+let map = https://prelude.dhall-lang.org/List/map
 
 let XML = https://prelude.dhall-lang.org/XML/package.dhall
 
 let Mock = ./dhall/Mock/package.dhall
 
-let User : Type = 
+let User : Type =
     { userId        : Text
     , username      : Text
     , createdDate   : Text
@@ -20,10 +20,15 @@ let users = [ { userId        = "7e38a4e7-5bd8-4011-9391-98ffdca58c06"
               , username      = "robert"
               , createdDate   = "2020-01-03T17:16:24"
               , lastLoginDate = "2020-04-04T13:00:02"
+              },
+              { userId        = "4c30413c-f04c-4a1f-ad22-6d8b9e84275b"
+              , username      = "gérard"
+              , createdDate   = "2019-08-04T11:12:45"
+              , lastLoginDate = "2020-04-05T10:15:09"
               }
             ]
 
-let mkUserBody = \(u : User) -> 
+let mkUserBody = \(u : User) ->
     XML.element { attributes = [ { mapKey = "userId"       , mapValue = u.userId }
                                , { mapKey = "username"     , mapValue = u.username }
                                , { mapKey = "createdDate"  , mapValue = u.createdDate }
@@ -43,4 +48,4 @@ let mkUserExpectation = \(user: User) ->
                  }
     }
 
-in Prelude.List.map User Mock.Expectation mkUserExpectation users
+in map User Mock.Expectation mkUserExpectation users

--- a/src/expectation/model.rs
+++ b/src/expectation/model.rs
@@ -1,5 +1,6 @@
 use serde::Deserialize;
 use std::cmp::PartialEq;
+use std::fmt::{Display, Formatter};
 
 #[derive(Debug)]
 pub struct IncomingRequest {
@@ -62,6 +63,36 @@ impl Expectation {
     ) -> Option<&'a Expectation> {
         expectations.iter().find(|e| e.test(req))
     }
+}
+
+impl Display for Expectation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "Expectation {{ \n\tRequest {} {} \n\tResponse {} {} \n\t\t{} \n}}",
+            self.request
+                .method
+                .as_ref()
+                .map(|method| format!("{:?}", method))
+                .unwrap_or("_".to_string()),
+            self.request.path.as_ref().unwrap_or(&"_".to_string()),
+            self.response
+                .status_code
+                .map(|method| format!("{}", method))
+                .unwrap_or("_".to_string()),
+            self.response
+                .status_reason
+                .as_ref()
+                .unwrap_or(&"_".to_string()),
+            self.response.body.as_ref().unwrap_or(&"_".to_string())
+        )
+    }
+}
+
+pub fn display_expectations(expectations: &Vec<Expectation>) -> String {
+    expectations.iter().fold(String::new(), |acc, expectation| {
+        format!("{}\n{}", acc, expectation)
+    })
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,48 +3,83 @@ use env_logger::Env;
 use log::{debug, info, warn};
 
 use crate::compiler::{compile_configuration, load_file};
+use crate::expectation::model::display_expectations;
 use crate::web::State;
 use std::sync::{Arc, RwLock};
+use std::time::Instant;
+use tokio::sync::mpsc::{channel, Receiver};
+use tokio::task::spawn_blocking;
 
 mod cli;
 mod compiler;
 mod expectation;
 mod web;
 
-#[tokio::main]
-async fn main() -> Result<(), Error> {
+fn main() -> Result<(), Error> {
     start_logger();
 
     let cli_args = cli::load_cli_args();
 
+    let loading_rt = tokio::runtime::Builder::new()
+        .threaded_scheduler()
+        .thread_stack_size(8 * 1024 * 1024)
+        .core_threads(1)
+        .max_threads(3)
+        .build()?;
+
+    let mut web_rt = tokio::runtime::Runtime::new()?;
+
     info!("Start dhall mock project 👋");
+    let (mut tx, rx) = channel(10);
+    let state = Arc::new(RwLock::new(State {
+        expectations: vec![],
+    }));
 
-    let expectations = cli_args
-        .configuration_files
-        .iter()
-        .flat_map(|configuration_file| {
-            debug!("Loading configuration file {}", configuration_file);
-            let configuration_result = load_file(configuration_file)
-                .and_then(|configuration| compile_configuration(&configuration))
-                .context("Error loading configuration");
-            match configuration_result {
-                Ok(expectations) => expectations.into_iter(),
-                Err(e) => {
-                    warn!("{}", e);
-                    Vec::new().into_iter()
-                }
-            }
-        })
-        .collect();
-    info!("Loaded expectations : {:?}", expectations);
+    let compiler_state = state.clone();
+    loading_rt.spawn(compiler_executor(rx, compiler_state));
 
-    let state = Arc::new(RwLock::new(State { expectations }));
-    web::web_server(state.clone(), cli_args.http_bind).await?;
-
-    Ok(())
+    let web_state = state.clone();
+    web_rt.block_on(async move {
+        for configuration in cli_args.configuration_files.iter() {
+            debug!("Send configuration file {}", configuration);
+            tx.send(configuration.clone()).await?;
+        }
+        web::web_server(web_state, cli_args.http_bind).await
+    })
 }
 
 fn start_logger() {
     let env = Env::new().filter_or("RUST_LOG", "INFO");
     env_logger::init_from_env(env);
+}
+
+async fn compiler_executor(mut receiver: Receiver<String>, state: Arc<RwLock<State>>) {
+    debug!("Dhall compiler task started");
+    while let Some(config) = receiver.recv().await {
+        debug!("Received config to load from file {}", config);
+        let state = state.clone();
+        spawn_blocking(move || {
+            info!("Start loading config {}", config);
+            let now = Instant::now();
+            let load_result = load_file(config.as_str())
+                .and_then(|configuration| compile_configuration(&configuration))
+                .context(format!("Error parsing dhall configuration {}", config));
+            info!("Loaded {} in {} secs", config, now.elapsed().as_secs());
+            match (load_result, state.write()) {
+                (Ok(mut expectations), Ok(mut state)) => {
+                    info!(
+                        "Loaded expectations : {}",
+                        display_expectations(&expectations)
+                    );
+                    state.expectations.append(expectations.as_mut());
+                }
+                (Err(e), _) => warn!("{:#}", e),
+                (_, Err(e)) => warn!(
+                    "Error mutating state for configuration {} , : {:#}",
+                    config, e
+                ),
+            }
+        });
+    }
+    receiver.close();
 }


### PR DESCRIPTION
## What this PR does

Remove auto generated main by tokio.
Add two runtime, one generated to run web server and process cli inputs and one for dhall configuration compilation.

Configuration is sended through a channel from web runtime to compilation runtime that compile it and update the state.

## Related

Closes: #33 

## Special notes for your reviewer

