### PR TITLE
Fix : Error on web server should crash appliation with informations

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -59,7 +59,7 @@ fn main() -> Result<(), Error> {
         }
     });
 
-    let result= web_rt.block_on(run_mock_server(
+    let result = web_rt.block_on(run_mock_server(
         cli_args.http_bind,
         cli_args.admin_http_bind,
         state.clone(),

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -5,6 +5,7 @@ use log::{info, warn};
 use signal_hook::iterator::Signals;
 
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 use tokio::sync::mpsc::channel;
 
 use dhall_mock::cli;
@@ -17,7 +18,7 @@ use tokio::sync::oneshot;
 
 fn main() -> Result<(), Error> {
     start_logger();
-    let web_rt = Runtime::new()?;
+    let mut web_rt = Runtime::new()?;
     let loading_rt = create_loader_runtime()?;
 
     let cli_args = cli::load_cli_args();
@@ -40,26 +41,32 @@ fn main() -> Result<(), Error> {
     // Start web server
     let (web_send_close, web_close_channel) = oneshot::channel::<()>();
     let (admin_send_close, admin_close_channel) = oneshot::channel::<()>();
-    web_rt.spawn(run_mock_server(
+
+    web_rt.spawn(async move {
+        // Wait for signal
+        let signals = Signals::new(&[signal_hook::SIGINT])?;
+        match signals.forever().next() {
+            Some(signal_hook::SIGINT) => {
+                web_send_close
+                    .send(())
+                    .unwrap_or_else(|_| warn!("Error graceful shutdown"));
+                admin_send_close
+                    .send(())
+                    .unwrap_or_else(|_| warn!("Error graceful shutdown"));
+                Ok(())
+            }
+            _ => Err(anyhow!("Captured signal that should not be managed")),
+        }
+    });
+
+    let result= web_rt.block_on(run_mock_server(
         cli_args.http_bind,
         cli_args.admin_http_bind,
         state.clone(),
         web_close_channel,
         admin_close_channel,
     ));
-
-    // Wait for signal
-    let signals = Signals::new(&[signal_hook::SIGINT])?;
-    match signals.forever().next() {
-        Some(signal_hook::SIGINT) => {
-            web_send_close
-                .send(())
-                .unwrap_or_else(|_| warn!("Error graceful shutdown"));
-            admin_send_close
-                .send(())
-                .unwrap_or_else(|_| warn!("Error graceful shutdown"));
-            Ok(())
-        }
-        _ => Err(anyhow!("Captured signal that should not be managed")),
-    }
+    web_rt.shutdown_timeout(Duration::from_secs(1));
+    loading_rt.shutdown_timeout(Duration::from_secs(1));
+    result
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -42,7 +42,7 @@ fn main() -> Result<(), Error> {
     let (web_send_close, web_close_channel) = oneshot::channel::<()>();
     let (admin_send_close, admin_close_channel) = oneshot::channel::<()>();
 
-    web_rt.spawn(async move {
+    std::thread::spawn(move || {
         // Wait for signal
         let signals = Signals::new(&[signal_hook::SIGINT])?;
         match signals.forever().next() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,13 +43,9 @@ pub async fn run_mock_server(
     let server = run_web_server(http_bind, state.clone(), close_web_channel);
     let admin_server = run_admin_server(admin_http_bind, state.clone(), close_admin_channel);
 
-    let (web, admin) =
-        tokio::try_join!(tokio::task::spawn(server), tokio::task::spawn(admin_server))?;
-    match (web, admin) {
-        (Err(e), _) => Err(anyhow::anyhow!(e)),
-        (_, Err(e)) => Err(anyhow::anyhow!(e)),
-        _ => Ok(()),
-    }
+    tokio::try_join!(server, admin_server)
+        .map(|_| ())
+        .context("Error on running web servers")
 }
 
 pub async fn run_web_server(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,8 @@ pub async fn run_mock_server(
     let (web, admin) =
         tokio::try_join!(tokio::task::spawn(server), tokio::task::spawn(admin_server))?;
     match (web, admin) {
-        (e @ Err(_), _) => e.context("Web server crashed unexpectedly."),
-        (_, e @ Err(_)) => e.context("Admin server crashed unexpectedly."),
+        (Err(e), _) => Err(anyhow::anyhow!(e)),
+        (_, Err(e)) => Err(anyhow::anyhow!(e)),
         _ => Ok(()),
     }
 }


### PR DESCRIPTION
## What this PR does

Change the main startup to handle web_server errors.
Handling stop signal is now moved in a separate thread and we block on web_servers to manage error.


## Related

Fixes : #42 
Depends on : #41 

## Special notes for your reviewer

New starting model with error on web runtime : 
![excalidraw-202041105736](https://user-images.githubusercontent.com/1640465/79747487-0a11b400-830c-11ea-8c1c-bd7ca681e33d.png)



