### PR TITLE
Use dhal mock type through github instead of local binding

### DIFF
--- a/dhall/error.dhall
+++ b/dhall/error.dhall
@@ -1,4 +1,4 @@
-let Mock = ./dhall/Mock/package.dhall
+let Mock = https://raw.githubusercontent.com/dhall-mock/dhall-mock/master/dhall/Mock/package.dhall
 
 let expectations = [
                        { request  = { method  = Some Mock.HttpMethod.GET

--- a/dhall/example.dhall
+++ b/dhall/example.dhall
@@ -2,7 +2,7 @@ let map = https://prelude.dhall-lang.org/List/map
 
 let XML = https://prelude.dhall-lang.org/XML/package.dhall
 
-let Mock = ./dhall/Mock/package.dhall
+let Mock = https://raw.githubusercontent.com/dhall-mock/dhall-mock/master/dhall/Mock/package.dhall
 
 let User : Type =
     { userId        : Text

--- a/dhall/static.dhall
+++ b/dhall/static.dhall
@@ -1,4 +1,4 @@
-let Mock = ./dhall/Mock/package.dhall
+let Mock = https://raw.githubusercontent.com/dhall-mock/dhall-mock/master/dhall/Mock/package.dhall
 
 let expectations = [
                        { request  = { method  = Some Mock.HttpMethod.GET


### PR DESCRIPTION
## What this PR does

Change dhall configuration to use Type from project trhugh github instead of local binding.
This behavior aim to be closer to user experience instead of local developper one.

## Related

Closes: #28 

## Special notes for your reviewer


