### PR TITLE
Add flag to wait for configuration compilation

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -9,8 +9,8 @@ use tokio::sync::mpsc::channel;
 
 use dhall_mock::cli;
 use dhall_mock::{
-    compiler_executor, create_loader_runtime, load_configuration_files, run_web_server, load_configuration,
-    start_logger, State,
+    compiler_executor, create_loader_runtime, load_configuration, load_configuration_files,
+    run_web_server, start_logger, State,
 };
 
 fn main() -> Result<(), Error> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,8 @@ pub struct CliOpt {
     /// http binding for server
     #[structopt(short, long, default_value = "0.0.0.0:8088")]
     pub http_bind: String,
+    #[structopt(short, long = "wait")]
+    pub wait_configuration_load: bool
 }
 
 pub fn load_cli_args() -> CliOpt {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,7 +10,7 @@ pub struct CliOpt {
     #[structopt(short, long, default_value = "0.0.0.0:8088")]
     pub http_bind: String,
     #[structopt(short, long = "wait")]
-    pub wait_configuration_load: bool
+    pub wait_configuration_load: bool,
 }
 
 pub fn load_cli_args() -> CliOpt {


### PR DESCRIPTION
## What this PR does

Add new flag on cli options to wait configruation compilation before start servers.
In main add a branch based on cli flag to spwan loadig of configuration or do it in main thread before start seb servers.


## Related

Fixes: #36 

## Special notes for your reviewer


