### PR TITLE
Admin: Compile and integrate dhall configuration on POST /expectations

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -6,12 +6,10 @@ use signal_hook::iterator::Signals;
 
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-use tokio::sync::mpsc::channel;
 
 use dhall_mock::cli;
 use dhall_mock::{
-    compiler_executor, create_loader_runtime, load_configuration_files, run_mock_server,
-    start_logger, State,
+    create_loader_runtime, load_configuration_files, run_mock_server, start_logger, State,
 };
 use tokio::runtime::Runtime;
 use tokio::sync::oneshot;
@@ -19,7 +17,7 @@ use tokio::sync::oneshot;
 fn main() -> Result<(), Error> {
     start_logger();
     let mut web_rt = Runtime::new()?;
-    let loading_rt = create_loader_runtime()?;
+    let loading_rt = Arc::new(create_loader_runtime()?);
 
     let cli_args = cli::load_cli_args();
 
@@ -28,15 +26,11 @@ fn main() -> Result<(), Error> {
         expectations: vec![],
     }));
 
-    let (config_sender, config_receiver) = channel(10);
-    // Start dhall configuration loader
-    loading_rt.spawn(compiler_executor(config_receiver, state.clone()));
-
-    // Load configuration files
-    loading_rt.spawn(load_configuration_files(
-        cli_args.configuration_files.into_iter(),
-        config_sender,
-    ));
+    load_configuration_files(
+        loading_rt.clone(),
+        state.clone(),
+        cli_args.configuration_files.into_iter()
+    );
 
     // Start web server
     let (web_send_close, web_close_channel) = oneshot::channel::<()>();
@@ -67,6 +61,7 @@ fn main() -> Result<(), Error> {
         admin_close_channel,
     ));
     web_rt.shutdown_timeout(Duration::from_secs(1));
-    loading_rt.shutdown_timeout(Duration::from_secs(1));
+    // Can't shutdown loading_rt as shutdown_timeout need to move value and we can't anymore since we are sharing via Arc this Runtime ...
+    // loading_rt.shutdown_timeout(Duration::from_secs(1));
     result
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -57,6 +57,7 @@ fn main() -> Result<(), Error> {
         cli_args.http_bind,
         cli_args.admin_http_bind,
         state.clone(),
+        loading_rt.clone(),
         web_close_channel,
         admin_close_channel,
     ));

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), Error> {
     load_configuration_files(
         loading_rt.clone(),
         state.clone(),
-        cli_args.configuration_files.into_iter()
+        cli_args.configuration_files.into_iter(),
     );
 
     // Start web server

--- a/src/expectation/model.rs
+++ b/src/expectation/model.rs
@@ -89,12 +89,6 @@ impl Display for Expectation {
     }
 }
 
-pub fn display_expectations(expectations: &Vec<Expectation>) -> String {
-    expectations.iter().fold(String::new(), |acc, expectation| {
-        format!("{}\n{}", acc, expectation)
-    })
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ pub async fn run_admin_server(
     web::admin_server(state, http_bind, loader_rt, close_channel).await
 }
 
-pub fn load_configuration_files<'a>(
+pub fn load_configuration_files(
     target_runtime: Arc<Runtime>,
     state: Arc<RwLock<State>>,
     configurations: impl Iterator<Item = String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use crate::expectation::model::Expectation;
 
 pub mod cli;
 pub mod compiler;
-mod expectation;
+pub mod expectation;
 mod web;
 
 pub struct State {

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -1,11 +1,11 @@
 extern crate dhall_mock;
 
+use dhall_mock::expectation::model::{Expectation, HttpMethod, HttpRequest, HttpResponse};
+use dhall_mock::State;
 use std::panic;
 use std::sync::{Arc, RwLock};
 use tokio::runtime;
 use tokio::sync::oneshot;
-use dhall_mock::State;
-use dhall_mock::expectation::model::{Expectation, HttpMethod, HttpRequest, HttpResponse};
 
 use reqwest::blocking::Client;
 
@@ -13,7 +13,6 @@ fn run_test<T>(test: T) -> ()
 where
     T: FnOnce(Arc<RwLock<State>>) -> () + panic::UnwindSafe,
 {
-
     let loader_rt = Arc::new(runtime::Runtime::new().unwrap());
     let mut web_rt = runtime::Runtime::new().unwrap();
     let (web_send_close, web_close_channel) = oneshot::channel::<()>();
@@ -26,7 +25,13 @@ where
         expectations: expectations,
     }));
 
-    let join = setup(&web_rt, loader_rt, state.clone(), web_close_channel, admin_close_channel);
+    let join = setup(
+        &web_rt,
+        loader_rt,
+        state.clone(),
+        web_close_channel,
+        admin_close_channel,
+    );
 
     let result = panic::catch_unwind(|| test(state.clone()));
 
@@ -104,13 +109,13 @@ fn test_admin_api_post_expectations() {
         let expected = Expectation {
             request: HttpRequest {
                 method: Some(HttpMethod::GET),
-                path: Some("/greet/toto".to_string())
+                path: Some("/greet/toto".to_string()),
             },
             response: HttpResponse {
                 status_code: Some(201),
                 status_reason: None,
-                body: Some("Hello, toto ! Ca vient du web".to_string())
-            }
+                body: Some("Hello, toto ! Ca vient du web".to_string()),
+            },
         };
 
         assert!(state.expectations.contains(&expected))
@@ -143,13 +148,13 @@ fn test_admin_fail_compile_configuration() {
         let expected = Expectation {
             request: HttpRequest {
                 method: Some(HttpMethod::GET),
-                path: Some("/greet/toto".to_string())
+                path: Some("/greet/toto".to_string()),
             },
             response: HttpResponse {
                 status_code: Some(201),
                 status_reason: None,
-                body: Some("Hello, toto ! Ca vient du web".to_string())
-            }
+                body: Some("Hello, toto ! Ca vient du web".to_string()),
+            },
         };
 
         assert!(!state.expectations.contains(&expected))

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -4,18 +4,31 @@ use std::panic;
 use std::sync::{Arc, RwLock};
 use tokio::runtime;
 use tokio::sync::oneshot;
+use dhall_mock::State;
+use dhall_mock::expectation::model::{Expectation, HttpMethod, HttpRequest, HttpResponse};
+
+use reqwest::blocking::Client;
 
 fn run_test<T>(test: T) -> ()
 where
-    T: FnOnce() -> () + panic::UnwindSafe,
+    T: FnOnce(Arc<RwLock<State>>) -> () + panic::UnwindSafe,
 {
+
+    let loader_rt = Arc::new(runtime::Runtime::new().unwrap());
     let mut web_rt = runtime::Runtime::new().unwrap();
     let (web_send_close, web_close_channel) = oneshot::channel::<()>();
     let (admin_send_close, admin_close_channel) = oneshot::channel::<()>();
 
-    let join = setup(&web_rt, web_close_channel, admin_close_channel);
+    let conf = dhall_mock::compiler::load_file("./dhall/static.dhall").unwrap();
+    let expectations = dhall_mock::compiler::compile_configuration(conf.as_ref()).unwrap();
 
-    let result = panic::catch_unwind(|| test());
+    let state = Arc::new(RwLock::new(dhall_mock::State {
+        expectations: expectations,
+    }));
+
+    let join = setup(&web_rt, loader_rt, state.clone(), web_close_channel, admin_close_channel);
+
+    let result = panic::catch_unwind(|| test(state.clone()));
 
     teardown(web_send_close, admin_send_close);
 
@@ -25,20 +38,16 @@ where
 
 fn setup(
     web_rt: &runtime::Runtime,
+    loader_rt: Arc<runtime::Runtime>,
+    state: Arc<RwLock<State>>,
     web_close_channel: oneshot::Receiver<()>,
     admin_close_channel: oneshot::Receiver<()>,
 ) -> tokio::task::JoinHandle<Result<(), anyhow::Error>> {
-    let conf = dhall_mock::compiler::load_file("./dhall/static.dhall").unwrap();
-    let expectations = dhall_mock::compiler::compile_configuration(conf.as_ref()).unwrap();
-
-    let state = Arc::new(RwLock::new(dhall_mock::State {
-        expectations: expectations,
-    }));
-
     web_rt.spawn(dhall_mock::run_mock_server(
         String::from("0.0.0.0:8088"),
         String::from("0.0.0.0:8089"),
         state,
+        loader_rt,
         web_close_channel,
         admin_close_channel,
     ))
@@ -51,7 +60,7 @@ fn teardown(web_send_close: oneshot::Sender<()>, admin_send_close: oneshot::Send
 
 #[test]
 fn test_api() {
-    run_test(|| {
+    run_test(|_| {
         let api = format!("http://{}:{}/greet/pwet", "localhost", 8088);
         let req = reqwest::blocking::get(&api).unwrap();
 
@@ -61,10 +70,88 @@ fn test_api() {
 
 #[test]
 fn test_admin_api() {
-    run_test(|| {
+    run_test(|_| {
         let api = format!("http://{}:{}/expectations", "localhost", 8089);
         let req = reqwest::blocking::get(&api).unwrap();
 
         assert_eq!(reqwest::StatusCode::OK, req.status());
+    })
+}
+
+#[test]
+fn test_admin_api_post_expectations() {
+    run_test(|state| {
+        let api = format!("http://{}:{}/expectations", "localhost", 8089);
+        let req = Client::builder().build().unwrap().post(&api).body(r#"
+        let Mock = https://raw.githubusercontent.com/dhall-mock/dhall-mock/master/dhall/Mock/package.dhall
+        let expectations = [
+                               { request  = { method  = Some Mock.HttpMethod.GET
+                                           , path    = Some "/greet/toto"
+                                           }
+                               , response = { statusCode   = Some +201
+                                               , statusReason = None Text
+                                               , body         = Some "Hello, toto ! Ca vient du web"
+                                               }
+                              }
+                           ]
+        in expectations
+        "#).send().unwrap();
+
+        assert_eq!(reqwest::StatusCode::CREATED, req.status());
+
+        let state = state.read().unwrap();
+
+        let expected = Expectation {
+            request: HttpRequest {
+                method: Some(HttpMethod::GET),
+                path: Some("/greet/toto".to_string())
+            },
+            response: HttpResponse {
+                status_code: Some(201),
+                status_reason: None,
+                body: Some("Hello, toto ! Ca vient du web".to_string())
+            }
+        };
+
+        assert!(state.expectations.contains(&expected))
+    })
+}
+
+#[test]
+fn test_admin_fail_compile_configuration() {
+    run_test(|state| {
+        let api = format!("http://{}:{}/expectations", "localhost", 8089);
+        let req = Client::builder().build().unwrap().post(&api).body(r#"
+        let Mock = https://raw.githubusercontent.com/dhall-mock/dhall-mock/master/dhall/Mock/package.dhall
+        let expectations = [
+                               { request  = { method  = Some Mock.HttpMethod.GET
+                                           , path    = Some "/greet/toto"
+                                           }
+                               , response = { statusCode   = Some +201
+                                               , statusReason = None Text
+                                               , body         = Some "Hello, toto ! Ca vient du web"
+                                               }
+                              }
+                           ]
+        in expectation
+        "#).send().unwrap();
+
+        assert_eq!(reqwest::StatusCode::BAD_REQUEST, req.status());
+
+        let state = state.read().unwrap();
+
+        let expected = Expectation {
+            request: HttpRequest {
+                method: Some(HttpMethod::GET),
+                path: Some("/greet/toto".to_string())
+            },
+            response: HttpResponse {
+                status_code: Some(201),
+                status_reason: None,
+                body: Some("Hello, toto ! Ca vient du web".to_string())
+            }
+        };
+
+        assert!(!state.expectations.contains(&expected))
     })
 }


### PR DESCRIPTION
## What this PR does

Add new route for admin server on `POST /expectations` to load the dhall configuration the request body and add it to the state if compilation is succesfull.
If compilation fail, return a 400 BadRequest, if succeed return 201 Created.

Change model of communication between admin server and compilation using direct reference to runtime.

## Related

Closes: #8 

## Special notes for your reviewer

This modifiation forced to change to an Arc of Runtime that dibled the ability to force shitdown.
Maybe we should go back to channel communication in the future. Working with twi Runtime seems kind of risky.


