### PR TITLE
Enrich mock api

### DIFF
--- a/dhall/Mock/package.dhall
+++ b/dhall/Mock/package.dhall
@@ -1,23 +1,67 @@
-let HttpMethod = < HEAD | PUT | POST | GET | DELETE >
+let HttpMethod = < CONNECT | DELETE | GET | HEAD | OPTIONS | PATCH | POST | PUT | TRACE >
 
-let HttpRequest : Type
-    = { method  : Optional HttpMethod
-      , path    : Optional Text
+let Body = < JSON : { json : Text } | TEXT : { text : Text } >
+
+let QueryParam = { key: Text, value: Text }
+
+let Header = { mapKey: Text, mapValue: Text }
+
+let HttpRequest
+    = { Type = { method  : Optional HttpMethod
+               , path    : Optional Text
+               , body    : Optional Body
+               , params  : List QueryParam
+               , headers : List Header
+               }
+      , default = { method  = None HttpMethod
+                  , path    = None Text
+                  , body    = None Body
+                  , params  = [] : List QueryParam
+                  , headers = [] : List Header
+                  }
       }
 
-let HttpResponse : Type =
-      { statusCode   : Optional Integer
-      , statusReason : Optional Text
-      , body         : Optional Text
+let HttpResponse 
+    = { Type = { statusCode   : Optional Natural
+               , statusReason : Optional Text
+               , body         : Optional Text
+               , headers      : List Header
+               }
+      , default = { statusCode   = None Natural
+                  , statusReason = None Text
+                  , body         = None Text
+                  , headers      = [] : List Header
+                  }
       }
 
 let Expectation : Type =
-      { request  : HttpRequest
-      , response : HttpResponse
+      { request  : HttpRequest.Type
+      , response : HttpResponse.Type
       }
 
-in { HttpMethod   = HttpMethod
-   , HttpRequest  = HttpRequest
-   , HttpResponse = HttpResponse
-   , Expectation  = Expectation
+let contentTypeJSON : Header = 
+  { mapKey = "Content-Type", mapValue = "application/json" }
+
+let contentTypeXML : Header = 
+  { mapKey = "Content-Type", mapValue = "application/xml" }
+
+let contentTypeText : Header = 
+  { mapKey = "Content-Type", mapValue = "text/plain"}
+
+in { HttpMethod      = HttpMethod
+   , QueryParam      = QueryParam
+   , Header          = Header
+   , Body            = Body
+   , HttpRequest     = HttpRequest
+   , HttpResponse    = HttpResponse
+   , Expectation     = Expectation
+   , statusOK            = Some 200
+   , statusCreated       = Some 201
+   , statusBadRequest    = Some 400
+   , statusUnauthorized  = Some 401
+   , statusForbidden     = Some 403
+   , statusNotFound      = Some 404
+   , statusInternalError = Some 500
+   , contentTypeJSON     = contentTypeJSON
+   , contentTypeXML      = contentTypeXML
    }

--- a/dhall/static.dhall
+++ b/dhall/static.dhall
@@ -1,21 +1,19 @@
-let Mock = https://raw.githubusercontent.com/dhall-mock/dhall-mock/master/dhall/Mock/package.dhall
+let Mock = ./dhall/Mock/package.dhall
 
 let expectations = [
-                       { request  = { method  = Some Mock.HttpMethod.GET
-                                   , path    = Some "/greet/pwet"
-                                   }
-                       , response = { statusCode   = Some +201
-                                       , statusReason = None Text
-                                       , body         = Some "Hello, pwet ! Comment que ca biche ?"
-                                       }
+                       { request  = Mock.HttpRequest::{ method  = Some Mock.HttpMethod.GET
+                                                      , path    = Some "/greet/pwet"
+                                                      }
+                       , response = Mock.HttpResponse::{ statusCode   = Mock.statusCreated
+                                                       , body         = Some "Hello, pwet ! Comment que ca biche ?"
+                                                       }
                       }
-                      ,{ request  = { method  = Some Mock.HttpMethod.GET
-                                   , path    = Some "/greet/wololo"
-                                   }
-                      , response = { statusCode   = Some +200
-                                   , statusReason = None Text
-                                   , body         = Some "Hello, Wololo !"
-                                   }
+                      ,{ request  = Mock.HttpRequest::{ method  = Some Mock.HttpMethod.GET
+                                                      , path    = Some "/greet/wololo"
+                                                      }
+                      , response = Mock.HttpResponse::{ statusCode   = Mock.statusOK
+                                                      , body         = Some "Hello, Wololo !"
+                                                      }
                       }
                    ]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@ use env_logger::Env;
 
 use anyhow::{Context, Error};
 
-use crate::mock::model::Expectation;
 use web::admin::{server as admin_server, AdminServerContext};
 use web::mock::{server as mock_server, MockServerContext};
 

--- a/src/mock/compilation.rs
+++ b/src/mock/compilation.rs
@@ -11,21 +11,20 @@ pub fn compile_configuration(configuration_content: &str) -> Result<Vec<Expectat
 mod test {
     use super::*;
     use crate::mock::model::{Expectation, HttpMethod, HttpRequest, HttpResponse};
+    use std::collections::HashMap;
 
     #[test]
     fn test_compile_configuration() {
         let data = r###"
             let Mock = ./dhall/Mock/package.dhall
 
-            let expectations = [{ request  = { method  = Some Mock.HttpMethod.GET
-                             , path    = Some "/greet/pwet"
-                             }
-                , response = { statusCode   = Some +200
-                             , statusReason = None Text
-                             , body         = Some "Hello, pwet !"
-                             }
-                }
-            ]
+            let expectations = [ { request  = Mock.HttpRequest::{ method  = Some Mock.HttpMethod.GET
+                                                                , path    = Some "/greet/pwet"
+                                                                }
+                               , response = Mock.HttpResponse::{ statusCode   = Mock.statusOK
+                                                               , body         = Some "Hello, pwet !"
+                                                               }
+                               }]
 
             in expectations
         "###;
@@ -34,11 +33,15 @@ mod test {
             request: HttpRequest {
                 method: Some(HttpMethod::GET),
                 path: Some("/greet/pwet".to_string()),
+                body: None,
+                params: vec![],
+                headers: HashMap::new(),
             },
             response: HttpResponse {
                 status_code: Some(200),
                 status_reason: None,
                 body: Some("Hello, pwet !".to_string()),
+                headers: HashMap::new(),
             },
         }];
 

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -1,3 +1,4 @@
 mod compilation;
 pub mod model;
+pub mod serde;
 pub mod service;

--- a/src/mock/serde/mod.rs
+++ b/src/mock/serde/mod.rs
@@ -1,0 +1,45 @@
+pub mod json_string {
+    use serde::de::{self, Deserialize, DeserializeOwned, Deserializer};
+    use serde::ser::{self, Serialize, Serializer};
+    use serde_json;
+
+    pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: Serialize,
+        S: Serializer,
+    {
+        let j = serde_json::to_string(value).map_err(ser::Error::custom)?;
+        j.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+    where
+        T: DeserializeOwned,
+        D: Deserializer<'de>,
+    {
+        let j = String::deserialize(deserializer)?;
+        serde_json::from_str(&j).map_err(de::Error::custom)
+    }
+}
+
+pub mod dhall_listtomap {
+    use serde::de::{Deserialize, Deserializer};
+    use serde::ser::{Serialize, Serializer};
+    use std::collections::HashMap;
+
+    pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: Serialize,
+        S: Serializer,
+    {
+        value.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<HashMap<String, String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let j: Vec<(String, String)> = Vec::deserialize(deserializer)?;
+        Ok(j.into_iter().collect())
+    }
+}


### PR DESCRIPTION
## What this PR does

Support of Query parameters, Header and Body input in mock configuration.

TODO: filtering isn't implemented yet. (see #61)

## Related

See: #56 #61 


