### PR TITLE
Generate port randomly for integration tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,6 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -- --test-threads=1
 
   fmt:
     name: Rustfmt

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@ use env_logger::Env;
 
 use anyhow::{Context, Error};
 
-use crate::mock::model::Expectation;
 use web::admin::{server as admin_server, AdminServerContext};
 use web::mock::{server as mock_server, MockServerContext};
 

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -11,10 +11,23 @@ use tokio::sync::oneshot;
 use dhall_mock::web::admin::AdminServerContext;
 use dhall_mock::web::mock::MockServerContext;
 use reqwest::blocking::Client;
+use std::net::TcpListener;
+use std::time::Duration;
+
+fn get_available_port(bind: &str, excluded: Option<u16>) -> Option<u16> {
+    (30000..40000)
+        .filter(|port| excluded != Some(*port))
+        .find(|port| TcpListener::bind((bind, *port)).is_ok())
+}
+
+struct TestContext {
+    mock_bind: String,
+    admin_bind: String,
+}
 
 fn run_test<T>(test: T) -> ()
 where
-    T: FnOnce(Arc<RwLock<State>>) -> () + panic::UnwindSafe,
+    T: FnOnce(TestContext, Arc<RwLock<State>>) -> () + panic::UnwindSafe,
 {
     let mut loader_rt = runtime::Runtime::new().unwrap();
     let mut web_rt = runtime::Runtime::new().unwrap();
@@ -37,21 +50,38 @@ where
         })
         .unwrap();
 
+    let mock_port = get_available_port("127.0.0.1", None)
+        .expect("No port available to start mock server for test");
+    let admin_port = get_available_port("127.0.0.1", Some(mock_port))
+        .expect("No port available to start admin server for test");
+    let mock_bind = format!("127.0.0.1:{}", mock_port);
+    let admin_bind = format!("127.0.0.1:{}", admin_port);
+
+    println!("Start servers on {}, {}", mock_bind, admin_bind);
     let join = web_rt.spawn(start_servers(
         MockServerContext {
-            http_bind: "0.0.0.0:8088".to_string(),
+            http_bind: mock_bind.clone(),
             state: state.clone(),
             close_channel: web_close_channel,
         },
         AdminServerContext {
-            http_bind: "0.0.0.0:8089".to_string(),
+            http_bind: admin_bind.clone(),
             state: state.clone(),
             close_channel: admin_close_channel,
             target_runtime: Arc::new(loader_rt),
         },
     ));
+    std::thread::sleep(Duration::from_secs(2));
 
-    let result = panic::catch_unwind(|| test(state.clone()));
+    let result = panic::catch_unwind(|| {
+        test(
+            TestContext {
+                mock_bind,
+                admin_bind,
+            },
+            state.clone(),
+        )
+    });
 
     teardown(web_send_close, admin_send_close);
 
@@ -66,8 +96,8 @@ fn teardown(web_send_close: oneshot::Sender<()>, admin_send_close: oneshot::Send
 
 #[test]
 fn test_api() {
-    run_test(|_| {
-        let api = format!("http://{}:{}/greet/pwet", "localhost", 8088);
+    run_test(|test_context, _| {
+        let api = format!("http://{}/greet/pwet", test_context.mock_bind);
         let req = reqwest::blocking::get(&api).unwrap();
 
         assert_eq!(reqwest::StatusCode::CREATED, req.status());
@@ -76,8 +106,8 @@ fn test_api() {
 
 #[test]
 fn test_admin_api() {
-    run_test(|_| {
-        let api = format!("http://{}:{}/expectations", "localhost", 8089);
+    run_test(|test_context, _| {
+        let api = format!("http://{}/expectations", test_context.admin_bind);
         let req = reqwest::blocking::get(&api).unwrap();
 
         assert_eq!(reqwest::StatusCode::OK, req.status());
@@ -86,8 +116,8 @@ fn test_admin_api() {
 
 #[test]
 fn test_admin_api_post_expectations() {
-    run_test(|state| {
-        let api = format!("http://{}:{}/expectations", "localhost", 8089);
+    run_test(|test_context, state| {
+        let api = format!("http://{}/expectations", test_context.admin_bind);
         let req = Client::builder().build().unwrap().post(&api).body(r#"
         let Mock = https://raw.githubusercontent.com/dhall-mock/dhall-mock/master/dhall/Mock/package.dhall
         let expectations = [
@@ -125,8 +155,8 @@ fn test_admin_api_post_expectations() {
 
 #[test]
 fn test_admin_fail_compile_configuration() {
-    run_test(|state| {
-        let api = format!("http://{}:{}/expectations", "localhost", 8089);
+    run_test(|test_context, state| {
+        let api = format!("http://{}/expectations", test_context.admin_bind);
         let req = Client::builder().build().unwrap().post(&api).body(r#"
         let Mock = https://raw.githubusercontent.com/dhall-mock/dhall-mock/master/dhall/Mock/package.dhall
         let expectations = [


### PR DESCRIPTION
# What this PR does

Change integrations tests to randomly generate ports for servers to launch.  
This configuration allow to run tests concurrently

## Related

Fixes: #44 

## Special notes for your reviewer


