### PR TITLE
Feat/36 add wait option to load configuration

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -7,7 +7,7 @@ use signal_hook::iterator::Signals;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
-use dhall_mock::mock::service::{add_configuration, add_configuration_async, SharedState, State};
+use dhall_mock::mock::service::{add_configuration, SharedState, State};
 use dhall_mock::web::admin::AdminServerContext;
 use dhall_mock::web::mock::MockServerContext;
 use dhall_mock::{create_loader_runtime, start_logger, start_servers};
@@ -98,13 +98,9 @@ fn load_configuration_files(
                     };
                 } else {
                     target_runtime.spawn(async move {
-                        match add_configuration_async(
-                            state,
-                            configuration.clone(),
-                            configuration_content,
-                        )
-                        .await
-                        {
+                        match tokio::task::block_in_place(|| {
+                            add_configuration(state, configuration.clone(), configuration_content)
+                        }) {
                             Ok(()) => info!("Configuration {} loaded", configuration),
                             Err(e) => {
                                 warn!("Error loading configuration {} : {:#}", configuration, e)

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -7,10 +7,11 @@ use signal_hook::iterator::Signals;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
-use dhall_mock::mock::service::{add_configuration, SharedState, State};
+use dhall_mock::mock::service::{add_configuration, add_configuration_async, SharedState, State};
 use dhall_mock::web::admin::AdminServerContext;
 use dhall_mock::web::mock::MockServerContext;
 use dhall_mock::{create_loader_runtime, start_logger, start_servers};
+use std::borrow::BorrowMut;
 use std::fs;
 use structopt::StructOpt;
 use tokio::runtime::Runtime;
@@ -27,12 +28,14 @@ struct CliOpt {
     http_bind: String,
     #[structopt(short, long, default_value = "0.0.0.0:8089")]
     admin_http_bind: String,
+    #[structopt(short, long)]
+    wait: bool,
 }
 
 fn main() -> Result<(), Error> {
     start_logger()?;
     let mut web_rt = Runtime::new()?;
-    let loading_rt = Arc::new(create_loader_runtime()?);
+    let mut loading_rt = create_loader_runtime()?;
 
     let cli_args = CliOpt::from_args();
 
@@ -42,7 +45,8 @@ fn main() -> Result<(), Error> {
     }));
 
     load_configuration_files(
-        loading_rt.clone(),
+        loading_rt.borrow_mut(),
+        cli_args.wait,
         state.clone(),
         cli_args.configuration_files.into_iter(),
     );
@@ -63,7 +67,7 @@ fn main() -> Result<(), Error> {
         http_bind: cli_args.admin_http_bind,
         state: state.clone(),
         close_channel: admin_close_channel,
-        target_runtime: loading_rt,
+        target_runtime: Arc::new(loading_rt),
     };
 
     let result = web_rt.block_on(start_servers(mock_server_context, admin_server_context));
@@ -74,7 +78,8 @@ fn main() -> Result<(), Error> {
 }
 
 fn load_configuration_files(
-    target_runtime: Arc<Runtime>,
+    target_runtime: &mut Runtime,
+    wait: bool,
     state: SharedState,
     configurations: impl Iterator<Item = String>,
 ) {
@@ -84,14 +89,28 @@ fn load_configuration_files(
         {
             Ok(configuration_content) => {
                 let state = state.clone();
-                target_runtime.spawn(async move {
-                    match add_configuration(state, configuration.clone(), configuration_content)
-                        .await
-                    {
+                if wait {
+                    match add_configuration(state, configuration.clone(), configuration_content) {
                         Ok(()) => info!("Configuration {} loaded", configuration),
                         Err(e) => warn!("Error loading configuration {} : {:#}", configuration, e),
-                    }
-                });
+                    };
+                } else {
+                    target_runtime.spawn(async move {
+                        match add_configuration_async(
+                            state,
+                            configuration.clone(),
+                            configuration_content,
+                        )
+                        .await
+                        {
+                            Ok(()) => info!("Configuration {} loaded", configuration),
+                            Err(e) => {
+                                warn!("Error loading configuration {} : {:#}", configuration, e)
+                            }
+                        };
+                    });
+                    ()
+                }
             }
             Err(e) => warn!("Error loading configuration file : \n{:#}", e),
         }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -26,8 +26,10 @@ struct CliOpt {
     /// http binding for server
     #[structopt(short, long, default_value = "0.0.0.0:8088")]
     http_bind: String,
+    /// http binding for admin server
     #[structopt(short, long, default_value = "0.0.0.0:8089")]
     admin_http_bind: String,
+    /// wait to compile all configuration files before starting web servers
     #[structopt(short, long)]
     wait: bool,
 }

--- a/src/mock/service.rs
+++ b/src/mock/service.rs
@@ -16,15 +16,14 @@ pub struct State {
 pub type SharedState = Arc<RwLock<State>>;
 
 // TODO add unit tests
-pub async fn add_configuration(
+pub fn add_configuration(
     state: SharedState,
     id: String,
     configuration: String,
 ) -> Result<(), Error> {
     info!("Start load {} config", id);
     let now = Instant::now();
-    let result = block_in_place(move || compile_configuration(&configuration))
-        .context(format!("Error compiling {}", id));
+    let result = compile_configuration(&configuration).context(format!("Error compiling {}", id));
     info!("Loaded {}, in {} secs", id, now.elapsed().as_secs());
     let mut expectation = result?;
     let mut state = state
@@ -32,6 +31,14 @@ pub async fn add_configuration(
         .map_err(|_| anyhow!("Can't acquire write lock on state"))?;
     state.expectations.append(&mut expectation);
     Ok(())
+}
+
+pub async fn add_configuration_async(
+    state: SharedState,
+    id: String,
+    configuration: String,
+) -> Result<(), Error> {
+    block_in_place(move || add_configuration(state, id, configuration))
 }
 
 // Todo add Unit tests

--- a/src/mock/service.rs
+++ b/src/mock/service.rs
@@ -2,7 +2,6 @@ use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
 use log::info;
-use tokio::task::block_in_place;
 
 use anyhow::{anyhow, Context, Error};
 
@@ -31,14 +30,6 @@ pub fn add_configuration(
         .map_err(|_| anyhow!("Can't acquire write lock on state"))?;
     state.expectations.append(&mut expectation);
     Ok(())
-}
-
-pub async fn add_configuration_async(
-    state: SharedState,
-    id: String,
-    configuration: String,
-) -> Result<(), Error> {
-    block_in_place(move || add_configuration(state, id, configuration))
 }
 
 // Todo add Unit tests

--- a/src/web/admin.rs
+++ b/src/web/admin.rs
@@ -9,7 +9,7 @@ use tokio::sync::oneshot::Receiver;
 use anyhow::{anyhow, Context, Error};
 
 use super::not_found_response;
-use crate::mock::service::add_configuration_async;
+use crate::mock::service::add_configuration;
 use crate::mock::service::SharedState;
 use bytes::buf::BufExt;
 use std::io::Read;
@@ -82,11 +82,11 @@ async fn handler(
                 .read_to_string(&mut read_body)?;
 
             match target_runtime
-                .spawn(add_configuration_async(
-                    state,
-                    "POST web configuration".to_string(),
-                    read_body,
-                ))
+                .spawn(async {
+                    tokio::task::block_in_place(|| {
+                        add_configuration(state, "POST web configuration".to_string(), read_body)
+                    })
+                })
                 .await?
             {
                 Ok(()) => Response::builder()

--- a/src/web/admin.rs
+++ b/src/web/admin.rs
@@ -9,7 +9,7 @@ use tokio::sync::oneshot::Receiver;
 use anyhow::{anyhow, Context, Error};
 
 use super::not_found_response;
-use crate::mock::service::add_configuration;
+use crate::mock::service::add_configuration_async;
 use crate::mock::service::SharedState;
 use bytes::buf::BufExt;
 use std::io::Read;
@@ -82,7 +82,7 @@ async fn handler(
                 .read_to_string(&mut read_body)?;
 
             match target_runtime
-                .spawn(add_configuration(
+                .spawn(add_configuration_async(
                     state,
                     "POST web configuration".to_string(),
                     read_body,

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -25,7 +25,7 @@ where
     T: FnOnce(Arc<RwLock<State>>, u16, u16) -> () + panic::UnwindSafe,
 {
     let _ignore = dhall_mock::start_logger();
-    let mut loader_rt = runtime::Runtime::new().unwrap();
+    let loader_rt = runtime::Runtime::new().unwrap();
     let mut web_rt = runtime::Runtime::new().unwrap();
     let (web_send_close, web_close_channel) = oneshot::channel::<()>();
     let (admin_send_close, admin_close_channel) = oneshot::channel::<()>();
@@ -47,16 +47,7 @@ where
     .unwrap();
 
     let conf = fs::read_to_string("./dhall/static.dhall").unwrap();
-    loader_rt
-        .block_on(async {
-            tokio::task::spawn(add_configuration(
-                state.clone(),
-                "Init conf".to_string(),
-                conf,
-            ))
-            .await?
-        })
-        .unwrap();
+    add_configuration(state.clone(), "Init conf".to_string(), conf).unwrap();
 
     let join = web_rt.spawn(start_servers(
         MockServerContext {


### PR DESCRIPTION
## What this PR does

Change `service::add_configuration` to not be async by default.
Add `wait` flag in cli and load in future or in current thread on startup based on the flag.


## Related

Fixes : #36 

## Special notes for your reviewer


