### PR TITLE
Rework async runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+dependencies = [
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "maybe-uninit",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "dhall"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,11 +325,13 @@ dependencies = [
  "bytes",
  "colored",
  "env_logger",
- "get-port",
+ "futures",
  "hyper",
  "lazy_static",
  "log",
  "openssl-sys",
+ "rand",
+ "rayon",
  "reqwest",
  "rustls",
  "serde",
@@ -414,12 +463,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
+name = "futures"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8e3078b7b2a8a671cb7a3d17b4760e4181ea243227776ba83fd043b4ca034e"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a4d35f7401e948629c9c3d6638fb9bf94e0b2121e96c3b428cc4e631f3eb74"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -427,6 +492,17 @@ name = "futures-core"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d674eaa0056896d5ada519900dbf97ead2e46a7b6621e8160d79e2f2e1e2784b"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc709ca1da6f66143b8c9bec8e6260181869893714e9b5a490b169b0414144ab"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -450,6 +526,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f57ed14da4603b2554682e9f2ff3c65d7567b53188db96cb71538217fc64581b"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,12 +558,17 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a894a0acddba51a2d49a6f4263b1e64b8c579ece8af50fa86503d52cd1eea34"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project",
  "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
  "slab",
 ]
 
@@ -487,12 +580,6 @@ checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 dependencies = [
  "typenum",
 ]
-
-[[package]]
-name = "get-port"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2681e6a467d914a882d14c5c04bd704171b93c5a4d2ab46f81b0097eaa365b3"
 
 [[package]]
 name = "getrandom"
@@ -765,10 +852,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
+name = "memoffset"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1124,6 +1226,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
+name = "proc-macro-nested"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,6 +1294,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rayon"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf6960dc9a5b4ee8d3e4c5787b4a112a8818e0290a42ff664ad60692fdf2032"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c4fec834fb6e6d2dd5eece3c7b432a52f0ba887cf40e595190c4107edc08bf"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
 ]
 
 [[package]]
@@ -1308,6 +1441,12 @@ dependencies = [
  "lazy_static",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,7 @@ dependencies = [
  "rand",
  "rayon",
  "reqwest",
+ "retry",
  "rustls",
  "serde",
  "serde_dhall",
@@ -1387,6 +1388,15 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "retry"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddadf3a46af916aa0fe6b8283e676b6bb5cbdf835d986d98a49d7345072341e5"
+dependencies = [
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,12 @@ tokio = { version = "0.2", features = ["full", "time"] }
 bytes = "0.5"
 structopt = "0.3"
 reqwest = { version = "0.10", features = ["blocking"] }
-get-port = "1.3.1"
 lazy_static = "1.4.0"
 openssl-sys = "*"
 url = "2.1.1"
+rayon = "1.4.1"
+rand = "0.7.3"
+futures = "0.3.6"
 
 [features]
 # Force openssl-sys to staticly link in the openssl library. Necessary when

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ url = "2.1.1"
 rayon = "1.4.1"
 rand = "0.7.3"
 futures = "0.3.6"
+retry = "1.1.0"
 
 [features]
 # Force openssl-sys to staticly link in the openssl library. Necessary when

--- a/src/bin/dhall_mock_server.rs
+++ b/src/bin/dhall_mock_server.rs
@@ -1,18 +1,17 @@
 extern crate dhall_mock;
 
-use anyhow::{Context, Error};
-use log::{info, warn};
-
+use std::fs;
 use std::sync::{Arc, RwLock};
 
-use dhall_mock::mock::service::{add_configuration, SharedState, State};
+use anyhow::{Context, Error};
+use futures::future::join_all;
+use log::{info, warn};
+use structopt::StructOpt;
+
+use dhall_mock::mock::service::{load_configuration, SharedState, State};
 use dhall_mock::web::admin::AdminServerContext;
 use dhall_mock::web::mock::MockServerContext;
-use dhall_mock::{create_loader_runtime, start_logger, start_servers};
-use std::borrow::BorrowMut;
-use std::fs;
-use structopt::StructOpt;
-use tokio::runtime::Runtime;
+use dhall_mock::{start_logger, start_servers};
 
 #[derive(StructOpt, Debug, Clone)]
 #[structopt(name = "dhall-mock")]
@@ -30,11 +29,9 @@ struct CliOpt {
     wait: bool,
 }
 
-fn main() -> Result<(), Error> {
+#[tokio::main]
+async fn main() -> Result<(), Error> {
     start_logger()?;
-    let mut web_rt = Runtime::new()?;
-    let mut loading_rt = create_loader_runtime()?;
-    let loading_rt_handle = loading_rt.handle().clone();
 
     let cli_args = CliOpt::from_args();
 
@@ -43,12 +40,18 @@ fn main() -> Result<(), Error> {
         expectations: vec![],
     }));
 
-    load_configuration_files(
-        loading_rt.borrow_mut(),
-        cli_args.wait,
-        state.clone(),
-        cli_args.configuration_files.into_iter(),
+    let load_configurations = join_all(
+        cli_args
+            .configuration_files
+            .into_iter()
+            .map(|configuration| load_configuration_file(state.clone(), configuration)),
     );
+
+    if cli_args.wait {
+        load_configurations.await;
+    } else {
+        tokio::task::spawn(load_configurations);
+    }
 
     let mock_server_context = MockServerContext {
         http_bind: cli_args.http_bind,
@@ -57,42 +60,24 @@ fn main() -> Result<(), Error> {
 
     let admin_server_context = AdminServerContext {
         http_bind: cli_args.admin_http_bind,
-        state: state,
-        loadind_rt_handle: loading_rt_handle,
+        state,
     };
 
-    let result = web_rt.block_on(start_servers(mock_server_context, admin_server_context));
-
-    result
+    start_servers(mock_server_context, admin_server_context).await
 }
 
-fn load_configuration_files(
-    target_runtime: &mut Runtime,
-    wait: bool,
+async fn load_configuration_file(
     state: SharedState,
-    configurations: impl Iterator<Item = String>,
-) {
-    for configuration in configurations {
-        match fs::read_to_string(configuration.as_str())
-            .context(format!("Error reading file {} content", configuration))
-        {
-            Ok(configuration_content) => {
-                let state = state.clone();
-                let load = move || match add_configuration(
-                    state,
-                    configuration.clone(),
-                    configuration_content,
-                ) {
-                    Ok(()) => info!("Configuration {} loaded", configuration),
-                    Err(e) => warn!("Error loading configuration {} : {:#}", configuration, e),
-                };
-                if wait {
-                    load();
-                } else {
-                    target_runtime.spawn(async move { tokio::task::block_in_place(load) });
-                }
-            }
-            Err(e) => warn!("Error loading configuration file : \n{:#}", e),
-        }
-    }
+    configuration_name: String,
+) -> Result<(), Error> {
+    let configuration = fs::read_to_string(configuration_name.as_str())
+        .context(format!("Error reading file {} content", configuration_name))?;
+    match load_configuration(state, configuration_name.clone(), configuration).await {
+        Ok(()) => info!("Configuration {} loaded", configuration_name),
+        Err(e) => warn!(
+            "Error loading configuration {} : {:#}",
+            configuration_name, e
+        ),
+    };
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,22 +1,11 @@
-use env_logger::Env;
-
 use anyhow::{anyhow, Context, Error};
+use env_logger::Env;
 
 use web::admin::{server as admin_server, AdminServerContext};
 use web::mock::{server as mock_server, MockServerContext};
 
 pub mod mock;
 pub mod web;
-
-pub fn create_loader_runtime() -> Result<tokio::runtime::Runtime, Error> {
-    tokio::runtime::Builder::new()
-        .threaded_scheduler()
-        .thread_stack_size(8 * 1024 * 1024)
-        .core_threads(1)
-        .max_threads(3)
-        .build()
-        .context("Error creating loader tokio runtime")
-}
 
 pub fn start_logger() -> Result<(), Error> {
     let env = Env::new().filter_or("RUST_LOG", "INFO");
@@ -28,7 +17,6 @@ pub fn start_logger() -> Result<(), Error> {
 pub async fn start_servers(
     mock_context: MockServerContext,
     admin_context: AdminServerContext,
-    // sigint: impl Future<Output = Result<(), Error>>,
 ) -> Result<(), Error> {
     tokio::try_join!(mock_server(mock_context), admin_server(admin_context),)
         .map(|_| ())

--- a/src/web/admin.rs
+++ b/src/web/admin.rs
@@ -45,6 +45,10 @@ pub(crate) async fn server(context: AdminServerContext) -> Result<(), Error> {
 
 async fn handler(req: Request<hyper::Body>, state: SharedState) -> Result<Response<Body>, Error> {
     match (req.method(), req.uri().path()) {
+        (&Method::GET, "/health") => Response::builder()
+            .status(StatusCode::OK)
+            .body(Body::empty())
+            .map_err(|_| anyhow!("Something bad happened.")),
         (&Method::GET, "/expectations") => {
             let read_state = state
                 .read()

--- a/src/web/utils.rs
+++ b/src/web/utils.rs
@@ -1,6 +1,7 @@
+use log::info;
 use tokio::signal;
 
 pub async fn sigint(service: String) {
     signal::ctrl_c().await.expect("failed to listen for event");
-    println!("shutdown : {}", service);
+    info!("shutdown : {}", service);
 }


### PR DESCRIPTION
## What this PR does
Rework async configuration to have only one Tokio runtime and using rayon for loading configuration in specific thread pool.

Switch main to using default macro expanded tokio runtime and define a lazy static ThreadPool in mock to handle loading configruation.
Sync between rayons threads and tokio runtime future is handled by oneshot channels.

## Related

Closes: #85 



## Special notes for your reviewer


