### PR TITLE
Refacto test_api after rework async runtimes 

### DIFF
--- a/src/web/admin.rs
+++ b/src/web/admin.rs
@@ -45,6 +45,10 @@ pub(crate) async fn server(context: AdminServerContext) -> Result<(), Error> {
 
 async fn handler(req: Request<hyper::Body>, state: SharedState) -> Result<Response<Body>, Error> {
     match (req.method(), req.uri().path()) {
+        (&Method::GET, "/health") => Response::builder()
+            .status(StatusCode::OK)
+            .body(Body::empty())
+            .map_err(|_| anyhow!("Something bad happened.")),
         (&Method::GET, "/expectations") => {
             let read_state = state
                 .read()

--- a/src/web/utils.rs
+++ b/src/web/utils.rs
@@ -1,6 +1,7 @@
+use log::info;
 use tokio::signal;
 
 pub async fn sigint(service: String) {
     signal::ctrl_c().await.expect("failed to listen for event");
-    println!("shutdown : {}", service);
+    info!("shutdown : {}", service);
 }


### PR DESCRIPTION
## What this PR does

Change starting server and testing in test_api
Add an heath check route in admin server

## Related

<!-- Example: 
Fixes: #2387
Closes: 
Metas: #14085 #8918
Rel: #34937 #34936
See:
-->

## Special notes for your reviewer


